### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A **Model Context Protocol (MCP) server** that provides programmatic access to the Israeli Central Bureau of Statistics (CBS) price indices and economic data. Built with TypeScript, this server offers 8 comprehensive tools for retrieving, analyzing, and calculating Israeli economic statistics.
 
+<a href="https://glama.ai/mcp/servers/@reuvenaor/israel-statistics-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@reuvenaor/israel-statistics-mcp/badge" alt="Israel Statistics MCP server" />
+</a>
+
 ## 🐳 **Installation & Usage**
 
 ### **Docker (Recommended)**


### PR DESCRIPTION
This PR adds a badge for the [Israel Statistics MCP](https://glama.ai/mcp/servers/@reuvenaor/israel-statistics-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@reuvenaor/israel-statistics-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@reuvenaor/israel-statistics-mcp/badge" alt="Israel Statistics MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.